### PR TITLE
Adding class to load and tag, and tests

### DIFF
--- a/Tagger.py
+++ b/Tagger.py
@@ -1,0 +1,55 @@
+# -*- coding: cp1254 -*-
+
+# Onur Yilmaz
+
+# Imports
+import yaml
+import os
+from nltk.tag.brill import BrillTagger
+
+from yaml.parser import ParserError
+
+class Tagger:
+    def __init__(self, tagger):
+        self.myTagger = tagger
+
+    @classmethod
+    def load(cls, modelFile):
+        if not os.path.exists(modelFile):
+            raise FileNotFoundError("The model file: {} not found.".format(modelFile))
+        try:
+            with open(modelFile) as file:
+                myTagger = yaml.load(file)
+            if not isinstance(myTagger, BrillTagger):
+                raise TypeError("The model file: {} could not be loaded as a nltk.tag.brill.BrillTagger object".format(
+                    modelFile
+                ))
+            return cls(myTagger)
+        except ParserError as error:
+            print(error)
+            raise TypeError("Could not load file {} as yaml file.".format(modelFile))
+
+    # Tagger function
+    def tag(self, sentence):
+        if not isinstance(sentence, str):
+            raise TypeError("Input sentence has to be of type str. Is of type {}".format(type(sentence)))
+        # Lower input
+        temp = [[t.lower()] for t in sentence.split()]
+        return_list = []
+        # Find tags
+        for token in temp:
+            return_list.append(self.myTagger.tag(token))
+
+        return_list = [t for [t] in return_list]
+        # Correct tags for printing
+        tag_list = [y for (x, y) in return_list]
+        tag_list = [(y.lower()).title() for y in tag_list]
+
+        # Zip input and tags
+        temp_list = zip([t for t in sentence.split()], tag_list)
+
+        return temp_list
+
+    # Make the initiated class callable in the same way as a function
+    def __call__(self, sentence):
+        return list(self.tag(sentence))

--- a/pos_tagger.py
+++ b/pos_tagger.py
@@ -3,30 +3,14 @@
 # Onur Yilmaz
 
 # Imports
-import yaml
+from .Tagger import Tagger
 
 # Open the file where tagger is saved
-f = open('my_tagger.yaml')
-myTagger = yaml.load(f)
+taggerFileName = 'my_tagger.yaml'
+myTagger = Tagger.load(taggerFileName)
 
-
-# Tagger function
+# Keep the original functionality intact
 def tag(sentence):
-    # Lower input
-    temp = [[t.lower()] for t in sentence.split()]
-    return_list = []
-    # Find tags
-    for token in temp:
-        return_list.append(myTagger.tag(token))
-
-    return_list = [t for [t] in return_list]
-    # Correct tags for printing
-    tag_list = [y for (x, y) in return_list]
-    tag_list = [(y.lower()).title() for y in tag_list]
-
-    # Zip input and tags
-    temp_list = zip([t for t in sentence.split()], tag_list)
-
-    return temp_list
+    return myTagger.tag(sentence)
 
 # End of code

--- a/pos_tagger.py
+++ b/pos_tagger.py
@@ -3,7 +3,7 @@
 # Onur Yilmaz
 
 # Imports
-from .Tagger import Tagger
+from Tagger import Tagger
 
 # Open the file where tagger is saved
 taggerFileName = 'my_tagger.yaml'

--- a/tests/testTagger.py
+++ b/tests/testTagger.py
@@ -1,0 +1,73 @@
+# -*- coding: cp1254 -*-
+
+# Onur Yilmaz
+import os
+import unittest
+import tempfile
+import shutil
+from nltk.tag.brill import BrillTagger
+
+from Tagger import Tagger
+
+class TestTaggerSetUp(unittest.TestCase):
+    def setUp(self):
+        self.tempDir = tempfile.mkdtemp()
+        self.filePath = 'my_tagger.yaml'
+
+    def test_load_file(self):
+        tagger = Tagger.load(self.filePath)
+        self.assertIsInstance(tagger.myTagger, BrillTagger)
+
+    def test_load_nonexisting(self):
+        with self.assertRaises(FileNotFoundError):
+            Tagger.load("this_file_definitely_doesnt_exist.txt")
+
+    def test_load_incorrectly(self):
+        temporaryFileName = os.path.join(self.tempDir, 'temporary_file.txt')
+        with open(temporaryFileName, 'w') as file:
+            file.write("This is a line that won't be able to be read")
+        with self.assertRaises(TypeError):
+            Tagger.load(temporaryFileName)
+
+    def tearDown(self):
+        shutil.rmtree(self.tempDir)
+
+class TestTagger(unittest.TestCase):
+    def setUp(self):
+        self.filePath = 'my_tagger.yaml'
+        self.tag = Tagger.load(self.filePath)
+
+    def test_extract_using_tag(self):
+        exampleText = "Babasý papazdý, ama bitkilere ve ziraata karþý ilgi duyuyordu"
+        result = [('Babasý', 'Noun_Nom'),
+                    ('papazdý,', 'Noun_Nom'),
+                    ('ama', 'Conj'),
+                    ('bitkilere', 'Noun_Nom'),
+                    ('ve', 'Conj'),
+                    ('ziraata', 'Noun_Nom'),
+                    ('karþý', 'Adj'),
+                    ('ilgi', 'Noun_Nom'),
+                    ('duyuyordu', 'Verb')]
+        resultZip = zip((item[0] for item in result), (item[1] for item in result))
+        extractedResult = self.tag.tag(exampleText)
+        self.assertIsInstance(resultZip, zip)
+        self.assertListEqual(list(resultZip), list(extractedResult))
+
+    def test_extract_using_text(self):
+        exampleText = "Babasý papazdý, ama bitkilere ve ziraata karþý ilgi duyuyordu"
+        result = [('Babasý', 'Noun_Nom'),
+                  ('papazdý,', 'Noun_Nom'),
+                  ('ama', 'Conj'),
+                  ('bitkilere', 'Noun_Nom'),
+                  ('ve', 'Conj'),
+                  ('ziraata', 'Noun_Nom'),
+                  ('karþý', 'Adj'),
+                  ('ilgi', 'Noun_Nom'),
+                  ('duyuyordu', 'Verb')]
+        extractedResult = self.tag(exampleText)
+        self.assertListEqual(extractedResult, result)
+
+    def test_extract_input_error(self):
+        exampleText = ['a', 'list', 'of', 'things']
+        with self.assertRaises(TypeError):
+            self.tag.tag(exampleText)


### PR DESCRIPTION
Hi!

I needed to be able to import the tag function without loading the model at import time, so I added a simple class that would handle loading the file from any generic path together with the tag function as well. To make its usage more similar to other pos tagger libraries (spacy) I also added a __call__ function.
The tests are for the Tagger class and written as unittests rather than nosetests.
pos_tagger.py works exactly as before and any code using it should not notice any difference in how its used.

Kind regards,
Andreas